### PR TITLE
the windows 7 box is without sp1, renamed template

### DIFF
--- a/build-basebox.bat
+++ b/build-basebox.bat
@@ -4,7 +4,7 @@ setlocal
 set pwd=%~dp0
 set basebox=./template/windows
 set flavour=virtualbox
-set template=windows7x64sp1
+set template=windows7x64
 
 echo "Building basebox: %basebox% for %flavour%"
 

--- a/build-basebox.sh
+++ b/build-basebox.sh
@@ -1,7 +1,7 @@
 #!/bin/bash 
 basebox=./template/windows
 flavour=virtualbox
-template=windows7x64sp1
+template=windows7x64
 
 echo "Building basebox: ${basebox} for ${flavour}"
 

--- a/template/windows/windows7x64.json
+++ b/template/windows/windows7x64.json
@@ -21,7 +21,7 @@
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "type": "vmware-iso",
-      "vm_name": "windows7x64sp1",
+      "vm_name": "windows7x64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "768",
@@ -62,13 +62,13 @@
           "1"
         ]
       ],
-      "vm_name": "windows7x64sp1"
+      "vm_name": "windows7x64"
     }
   ],
   "post-processors": [
     {
       "keep_input_artifact": false,
-      "output": "../../{{.Provider}}/windows7x64sp1.box",
+      "output": "../../{{.Provider}}/windows7x64.box",
       "type": "vagrant"
     }
   ],


### PR DESCRIPTION
The windows 7 ISO used does not contain the SP1, so rename the base box to make it more clear.
